### PR TITLE
Build fixes for GNU/Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ CXXFLAGS += $(CPPFLAGS)
 CFLAGS += -ffast-math -fomit-frame-pointer
 CXXFLAGS += -ffast-math -fomit-frame-pointer
 
+ifeq "$(findstring Linux,$(OSTYPE))" "Linux"
+CFLAGS += -I/usr/include/libdwarf
+CXXFLAGS += -I/usr/include/libdwarf
+endif
+
 # Flags to pass on to qmake...
 QMAKE_EXTRA += "QMAKE_CFLAGS_RELEASE=$(CFLAGS)"
 QMAKE_EXTRA += "QMAKE_CXXFLAGS_RELEASE=$(CXXFLAGS)"
@@ -44,6 +49,12 @@ QMAKE_EXTRA += "QMAKE_CFLAGS_DEBUG=$(CFLAGS)"
 QMAKE_EXTRA += "QMAKE_CXXFLAGS_DEBUG=$(CXXFLAGS)"
 QMAKE_EXTRA += "QMAKE_LFLAGS_DEBUG=$(LDFLAGS)"
 
+# Add Qt flags on GNU/Linux since core code uses Qt Widgets now
+ifeq "$(findstring Linux,$(OSTYPE))" "Linux"
+CFLAGS += $(shell pkg-config --cflags Qt5Widgets)
+CXXFLAGS += $(shell pkg-config --cflags Qt5Widgets)
+LDFLAGS += $(shell pkg-config --libs Qt5Widgets)
+endif
 
 all: prepare virtualjaguar
 	@echo -e "\033[01;33m***\033[00;32m Success!\033[00m"

--- a/src/m68000/Makefile
+++ b/src/m68000/Makefile
@@ -61,7 +61,7 @@ obj/%.o: obj/%.c
 
 # Generated code
 
-obj/cpuemu.c: obj/gencpu
+obj/cpuemu.c: obj/gencpu obj/cpustbl.c
 obj/cpustbl.c: obj/gencpu
 	@echo -e "\033[01;33m***\033[00;32m Generating cpuemu.c...\033[00m"
 	@cd obj && ./gencpu


### PR DESCRIPTION
Just a couple of small updates to the Makefiles to:

1. Fix parallel builds (failing due to gencpu not being run before make tries to build cpuemu.c)
2. Deal with cases where libdwarf-dev installs headers to /usr/include/libdwarf and not /usr/include
3. Add QtWidgets cflags and ldflags since jaguar core directly uses Qt Widgets now and headers are installed to version specific directories on GNU/Linux

If you wanted anything done differently, let me know.