### PR TITLE
Fixes & improvements

### DIFF
--- a/src/debugger/DWARFManager.cpp
+++ b/src/debugger/DWARFManager.cpp
@@ -17,6 +17,7 @@
 // JPM   Apr./2021  Support the structure and union members
 // JPM   June/2021  Update the source file path clean up
 // JPM   Oct./2021  Support wider offset ranges for local and parameter variables
+// JPM  March/2022  Added a '/cygdrive/' directory detection
 //
 
 // To Do
@@ -531,6 +532,20 @@ void DWARFManager_InitDMI(void)
 								{
 									PtrCU[NbCU].PtrSourceFileDirectory = (char *)realloc(PtrCU[NbCU].PtrSourceFileDirectory, 2);
 									strcpy(PtrCU[NbCU].PtrSourceFileDirectory, ".");
+								}
+							}
+							else
+							{
+								// handle the /cygdrive/ presence in the directory filename
+								if (!strncmp(PtrCU[NbCU].PtrSourceFileDirectory, "/cygdrive/", 10))
+								{
+									strcpy(PtrCU[NbCU].PtrSourceFileDirectory, &PtrCU[NbCU].PtrSourceFileDirectory[9]);
+									if ((PtrCU[NbCU].PtrSourceFileDirectory[0] == '/') && (PtrCU[NbCU].PtrSourceFileDirectory[2] == '/') && (PtrCU[NbCU].PtrSourceFileDirectory[1] >= 'a') && (PtrCU[NbCU].PtrSourceFileDirectory[1] <= 'z'))
+									{
+										PtrCU[NbCU].PtrSourceFileDirectory[0] = PtrCU[NbCU].PtrSourceFileDirectory[1];
+										PtrCU[NbCU].PtrSourceFileDirectory[1] = ':';
+										PtrCU[NbCU].PtrSourceFileDirectory = (char*)realloc(PtrCU[NbCU].PtrSourceFileDirectory, strlen(PtrCU[NbCU].PtrSourceFileDirectory) + 1);
+									}
 								}
 							}
 

--- a/src/debugger/debuggertab.cpp
+++ b/src/debugger/debuggertab.cpp
@@ -12,6 +12,7 @@
 // JPM  10/09/2018  Added source file search paths
 // JPM  04/06/2019  Added ELF sections check
 //  RG   Jan./2021  Linux build fix
+// JPM  March/2022  Added a '/cygdrive/' directory removal option
 //
 
 #include "debuggertab.h"
@@ -52,6 +53,7 @@ DebuggerTab::DebuggerTab(QWidget * parent/*= 0*/): QWidget(parent)
 	layout4->addLayout(layout7);
 
 	// Checkboxes
+	cygdriveDirRemoval = new QCheckBox(tr("/cygdrive/ directory reference removal"));
 	displayHWlabels = new QCheckBox(tr("Display HW labels"));
 	disasmopcodes	= new QCheckBox(tr("Display M68000 opcodes"));
 	displayFullSourceFilename = new QCheckBox(tr("Display source filename"));
@@ -60,7 +62,9 @@ DebuggerTab::DebuggerTab(QWidget * parent/*= 0*/): QWidget(parent)
 	displayHWlabels->setDisabled(false);
 	displayFullSourceFilename->setDisabled(false);
 	ELFSectionsCheck->setDisabled(false);
+	cygdriveDirRemoval->setDisabled(true);
 
+	layout4->addWidget(cygdriveDirRemoval);
 	layout4->addWidget(disasmopcodes);
 	layout4->addWidget(displayHWlabels);
 	layout4->addWidget(displayFullSourceFilename);
@@ -88,6 +92,7 @@ void DebuggerTab::SetSettings(void)
 	vjs.disasmopcodes = disasmopcodes->isChecked();
 	vjs.displayFullSourceFilename = displayFullSourceFilename->isChecked();
 	vjs.ELFSectionsCheck = ELFSectionsCheck->isChecked();
+	vjs.cygdriveDirRemoval = cygdriveDirRemoval->isChecked();
 }
 
 
@@ -95,12 +100,14 @@ void DebuggerTab::SetSettings(void)
 void DebuggerTab::GetSettings(void)
 {
 	QVariant v((qulonglong) vjs.nbrdisasmlines);
+
 	nbrdisasmlines->setText(v.toString());
 	sourcefilesearchpaths->setText(vjs.sourcefilesearchPaths);
 	displayHWlabels->setChecked(vjs.displayHWlabels);
 	disasmopcodes->setChecked(vjs.disasmopcodes);
 	displayFullSourceFilename->setChecked(vjs.displayFullSourceFilename);
 	ELFSectionsCheck->setChecked(vjs.ELFSectionsCheck);
+	cygdriveDirRemoval->setChecked(vjs.cygdriveDirRemoval);
 }
 
 

--- a/src/debugger/debuggertab.h
+++ b/src/debugger/debuggertab.h
@@ -6,6 +6,7 @@
 // JPM  Sept./2016  Created this file, and added Soft debugger support
 // JPM  10/09/2018  Added the source file search paths
 // JPM  04/06/2019  Added ELF sections check
+// JPM  March/2022  Added a '/cygdrive/' directory removal option
 //
 
 #ifndef __DEBUGGERTAB_H__
@@ -33,6 +34,7 @@ class DebuggerTab: public QWidget
 		QCheckBox *disasmopcodes;
 		QCheckBox *displayFullSourceFilename;
 		QCheckBox *ELFSectionsCheck;
+		QCheckBox *cygdriveDirRemoval;
 };
 
 #endif	// __DEBUGGERTAB_H__

--- a/src/gui/alpinetab.cpp
+++ b/src/gui/alpinetab.cpp
@@ -13,6 +13,7 @@
 // JLH  07/15/2011  Created this file
 // JPM  09/03/2018  Depend the platform transform slashes or backslashes
 // JPM   Feb./2021  Added a M68K exception catch check
+// JPM   Jan./2022  Added a writes to unknown memory location catch
 //
 
 #include "alpinetab.h"
@@ -62,6 +63,7 @@ AlpineTab::AlpineTab(QWidget * parent/*= 0*/): QWidget(parent)
 	// Checkboxes...
 	writeROM = new QCheckBox(tr("Allow writes to cartridge ROM"));
 	M68KExceptionCatch = new QCheckBox(tr("Allow M68000 exception catch"));
+	WriteUnknownMemoryLocation = new QCheckBox(tr("Allow writes to unknown memory location"));
 //	useDSP             = new QCheckBox(tr("Enable DSP"));
 //	useHostAudio       = new QCheckBox(tr("Enable audio playback"));
 //	useUnknownSoftware = new QCheckBox(tr("Allow unknown software in file chooser"));
@@ -70,6 +72,7 @@ AlpineTab::AlpineTab(QWidget * parent/*= 0*/): QWidget(parent)
 
 	layout4->addWidget(writeROM);
 	layout4->addWidget(M68KExceptionCatch);
+	layout4->addWidget(WriteUnknownMemoryLocation);
 //	layout4->addWidget(useDSP);
 //	layout4->addWidget(useHostAudio);
 //	layout4->addWidget(useUnknownSoftware);
@@ -93,6 +96,7 @@ void AlpineTab::GetSettings(void)
 	edit3->setText(v.toString());
 	writeROM->setChecked(vjs.allowWritesToROM);
 	M68KExceptionCatch->setChecked(vjs.allowM68KExceptionCatch);
+	WriteUnknownMemoryLocation->setChecked(vjs.allowWritesToUnknownLocation);
 }
 
 
@@ -106,6 +110,7 @@ void AlpineTab::SetSettings(void)
 	vjs.refresh = edit3->text().toUInt(&ok, 10);
 	vjs.allowWritesToROM = writeROM->isChecked();
 	vjs.allowM68KExceptionCatch = M68KExceptionCatch->isChecked();
+	vjs.allowWritesToUnknownLocation = WriteUnknownMemoryLocation->isChecked();
 }
 
 

--- a/src/gui/alpinetab.h
+++ b/src/gui/alpinetab.h
@@ -17,16 +17,17 @@ class AlpineTab: public QWidget
 		QString CheckForSlashes(QString);
 
 	public:
-		QLineEdit * edit1;
-		QLineEdit * edit2;
-		QLineEdit * edit3;
-//		QLineEdit * edit3;
-//		QLineEdit * edit4;
-		QCheckBox * writeROM;
-		QCheckBox * M68KExceptionCatch;
-//		QCheckBox * useDSP;
-//		QCheckBox * useHostAudio;
-//		QCheckBox * useUnknownSoftware;
+		QLineEdit *edit1;
+		QLineEdit *edit2;
+		QLineEdit *edit3;
+//		QLineEdit *edit3;
+//		QLineEdit *edit4;
+		QCheckBox *writeROM;
+		QCheckBox *M68KExceptionCatch;
+		QCheckBox *WriteUnknownMemoryLocation;
+//		QCheckBox *useDSP;
+//		QCheckBox *useHostAudio;
+//		QCheckBox *useUnknownSoftware;
 };
 
 #endif	// __ALPINETAB_H__

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -23,7 +23,7 @@
 
 #include "app.h"
 
-#include <SDL.h>
+#include "SDL.h"
 #include <QtWidgets/QApplication>
 #include "gamepad.h"
 #include "log.h"
@@ -37,6 +37,7 @@
 #if defined (__GCCWIN32__) || defined (_MSC_VER)
 #undef main
 #include <windows.h>	// Ick, but needed for console redirection on win32 :-O
+#include <fstream>
 #endif
 
 // Function prototypes...
@@ -63,7 +64,7 @@ int main(int argc, char * argv[])
 
 	AttachConsole = (BOOL (WINAPI *)(DWORD))GetProcAddress(LoadLibraryA("kernel32.dll"), "AttachConsole");
 
-	if (AttachConsole != NULL && AttachConsole(((DWORD)-1)))
+	if ((AttachConsole != NULL) && AttachConsole(((DWORD)-1)))
 	{
 		if (_fileno(stdout) == -1)
 			freopen("CONOUT$", "wb", stdout);

--- a/src/gui/debug/hwregsblitterbrowser.cpp
+++ b/src/gui/debug/hwregsblitterbrowser.cpp
@@ -8,6 +8,8 @@
 // Who  When        What
 // ---  ----------  -----------------------------------------------------------
 // JPM  08/20/2019  Created this file
+// JPM   Oct./2021  Added the register's name
+// JPM   Jan./2022  Fix for the 64bits values
 //
 
 // STILL TO DO:
@@ -16,53 +18,60 @@
 #include "hwregsbrowser.h"
 #include "blitter.h"
 
+#define INV64(a)	(((a) >> 56) | (((a) & 0x00ff000000000000) >> 40) | (((a) & 0x0000ff0000000000) >> 24) | (((a) & 0x000000ff00000000) >> 8 ) | (((a) & 0x00000000ff000000) << 8 ) | (((a) & 0x0000000000ff0000) << 24) | (((a) & 0x000000000000ff00) << 40) | (((a) & 0x00000000000000ff) << 56))
+#define INV32(a)	((((a) & 0xff000000) >> 24) | (((a) & 0x00ff0000) >> 8) | (((a) & 0x0000ff00) << 8) | (((a) & 0xff) << 24)))
+
+extern uint8_t blitter_ram[];
+
 
 //
 struct BlitterInfoTable
 {
+	const char *RegisterName;
 	unsigned int Address;
-	unsigned int NbBits;
+	unsigned int NbBytes;
 	const char *Name;
 	const char *Type;
 }
 S_BlitterInfoTable;
 
-//
+// Information table for the Blitter
+// References: Jaguar Software Reference Manual - Version 2.4
 BlitterInfoTable TabBlitterInfoTable[] = {
-											{	0xF02200, sizeof(long), "A1 base address", "32-bit register containing a pointer to the base of the window pointer to by A1.\nThis address must be phrase aligned."	},
-											{	0xF02204, sizeof(long), "Flags Register", "A set of flags controlling various aspects of the A1 window and how addresses are updated."	},
-											{	0xF02208, sizeof(long), "A1 Clipping Window Size", "This register contains the size in pixels, and may be used for clipping writes, so that if the pointer leaves the window bounds no write is performed."	},
-											{	0xF0220C, sizeof(long), "A1 Window Pixel Pointer", "This register contains the X (low word) and Y (high word) pointers onto the window, and are the location where the next pixel will be written.\nThey are sixteen - bit signed values."	},
-											{	0xF02210, sizeof(long), "A1 Step Value", "The step register contains two signed sixteen bit values, which are the X step (low word) and Y step (high word)."	},
-											{	0xF02214, sizeof(long), "A1 Step Fraction Value", "The step fraction register may be added to the fractional parts of the A1 pointer in the same manner as the step value."	},
-											{	0xF02218, sizeof(long), "A1 Window Pixel Pointer Fraction", ""	},
-											{	0xF0221C, sizeof(long), "A1 Pixel Pointer Increment", ""	},
-											{	0xF02220, sizeof(long), "A1 Pixel Pointer Increment Fraction", "This is the fractional parts of the increment described above."	},
-											{	0xF02224, sizeof(long), "A2 Base Register", "32-bit register containing a pointer to the base of the window pointer to by A2.\nThis address must be phrase aligned."	},
-											{	0xF02228, sizeof(long), "A2 Flags Register", "A set of flags controlling various aspects of the A2 window and how addresses are updated."	},
-											{	0xF0222C, sizeof(long), "A2 Window Mask", ""	},
-											{	0xF02230, sizeof(long), "A2 Window Pointer", ""	},
-											{	0xF02234, sizeof(long), "A2 Step Value", ""	},
-											{	0xF02238, sizeof(long), "Status Register", ""	},
-											{	0xF0223C, sizeof(long), "Counters Register", ""	},
-											{	0xF02240, sizeof(long long), "Source Data Register", ""	},
-											{	0xF02248, sizeof(long long), "Destination Data Register", ""	},
-											{	0xF02250, sizeof(long long), "Destination Z Register", ""	},
-											{	0xF02258, sizeof(long long), "Source Z Register 1", "The source Z register 1 is also used to hold the four integer parts of computed Z."	},
-											{	0xF02260, sizeof(long long), "Source Z Register 2", "The source Z register 2 is also used to hold the four fraction parts of computed Z."	},
-											{	0xF02268, sizeof(long long), "Pattern Data Register", "The pattern data register also serves to hold the computed intensity integer parts and their associated colours."	},
-											{	0xF02270, sizeof(long), "Intensity Increment", "This thirty-two bit register holds the integer and fractional parts of the intensity increment used for Gouraud shading."	},
-											{	0xF02274, sizeof(long), "Z Increment", "This thirty-two bit register holds the integer and fractional parts of the Z increment used for computed Z polygon drawing."	},
-											{	0xF02278, sizeof(long), "Collision control", ""	},
-											{	0xF0227C, sizeof(long), "Intensity 0", ""	},
-											{	0xF02280, sizeof(long), "Intensity 1", ""	},
-											{	0xF02284, sizeof(long), "Intensity 2", ""	},
-											{	0xF02288, sizeof(long), "Intensity 3", ""	},
-											{	0xF0228C, sizeof(long), "Z 0", "These registers are analogous to the intensity registers, and are for Z buffer operation."	},
-											{	0xF02290, sizeof(long), "Z 1", "These registers are analogous to the intensity registers, and are for Z buffer operation."	},
-											{	0xF02294, sizeof(long), "Z 2", "These registers are analogous to the intensity registers, and are for Z buffer operation."	},
-											{	0xF02298, sizeof(long), "Z 3", "These registers are analogous to the intensity registers, and are for Z buffer operation."	},
-										};
+	{	"A1_BASE", 0xF02200, sizeof(uint32_t), "A1 Base Register", "32-bit register containing a pointer to the base of the window pointer to by A1.\nThis address must be phrase aligned."	},
+	{	"A1_FLAGS", 0xF02204, sizeof(uint32_t), "A1 Flags Register", "A set of flags controlling various aspects of the A1 window and how addresses are updated."	},
+	{	"A1_CLIP", 0xF02208, sizeof(uint32_t), "A1 Clipping Size", "This register contains the size in pixels, and may be used for clipping writes, so that if the pointer leaves the window bounds no write is performed."	},
+	{	"A1_PIXEL", 0xF0220C, sizeof(uint32_t), "A1 Pixel Pointer", "This register contains the X (low word) and Y (high word) pointers onto the window, and are the location where the next pixel will be written.\nThey are sixteen - bit signed values."	},
+	{	"A1_STEP", 0xF02210, sizeof(uint32_t), "A1 Step Value", "The step register contains two signed sixteen bit values, which are the X step (low word) and Y step (high word)."	},
+	{	"A1_FSTEP", 0xF02214, sizeof(uint32_t), "A1 Step Fraction Value", "The step fraction register may be added to the fractional parts of the A1 pointer in the same manner as the step value."	},
+	{	"A1_FPIXEL", 0xF02218, sizeof(uint32_t), "A1 Pixel Pointer Fraction", ""	},
+	{	"A1_INC", 0xF0221C, sizeof(uint32_t), "A1 Increment", ""	},
+	{	"A1_FINC", 0xF02220, sizeof(uint32_t), "A1 Increment Fraction", "This is the fractional parts of the increment described above."	},
+	{	"A2_BASE", 0xF02224, sizeof(uint32_t), "A2 Base Register", "32-bit register containing a pointer to the base of the window pointer to by A2.\nThis address must be phrase aligned."	},
+	{	"A2_FLAGS", 0xF02228, sizeof(uint32_t), "A2 Flags Register", "A set of flags controlling various aspects of the A2 window and how addresses are updated."	},
+	{	"A2_MASK", 0xF0222C, sizeof(uint32_t), "A2 Window Mask", ""	},
+	{	"A2_PIXEL", 0xF02230, sizeof(uint32_t), "A2 Pixel Pointer", ""	},
+	{	"A2_STEP", 0xF02234, sizeof(uint32_t), "A2 Step Value", ""	},
+	{	"B_CMD", 0xF02238, sizeof(uint32_t), "Command Register", ""	},
+	{	"B_COUNT", 0xF0223C, sizeof(uint32_t), "Counters Register", ""	},
+	{	"B_SRCD", 0xF02240, sizeof(uint64_t), "Source Data Register", ""	},
+	{	"B_DSTD", 0xF02248, sizeof(uint64_t), "Destination Data Register", ""	},
+	{	"B_DSTZ", 0xF02250, sizeof(uint64_t), "Destination Z Register", ""	},
+	{	"B_SRCZ1", 0xF02258, sizeof(uint64_t), "Source Z Register 1", "The source Z register 1 is also used to hold the four integer parts of computed Z."	},
+	{	"B_SRCZ2", 0xF02260, sizeof(uint64_t), "Source Z Register 2", "The source Z register 2 is also used to hold the four fraction parts of computed Z."	},
+	{	"B_PATD", 0xF02268, sizeof(uint64_t), "Pattern Data Register", "The pattern data register also serves to hold the computed intensity integer parts and their associated colours."	},
+	{	"B_IINC", 0xF02270, sizeof(uint32_t), "Intensity Increment", "This thirty-two bit register holds the integer and fractional parts of the intensity increment used for Gouraud shading."	},
+	{	"B_ZINC", 0xF02274, sizeof(uint32_t), "Z Increment", "This thirty-two bit register holds the integer and fractional parts of the Z increment used for computed Z polygon drawing."	},
+	{	"B_STOP", 0xF02278, sizeof(uint32_t), "Collision control", ""	},
+	{	"B_I3", 0xF0227C, sizeof(uint32_t), "Intensity 3", ""	},
+	{	"B_I2", 0xF02280, sizeof(uint32_t), "Intensity 2", ""	},
+	{	"B_I1", 0xF02284, sizeof(uint32_t), "Intensity 1", ""	},
+	{	"B_I0", 0xF02288, sizeof(uint32_t), "Intensity 0", ""	},
+	{	"B_Z3", 0xF0228C, sizeof(uint32_t), "Z3", "These registers are analogous to the intensity registers, and are for Z buffer operation."	},
+	{	"B_Z2", 0xF02290, sizeof(uint32_t), "Z2", "These registers are analogous to the intensity registers, and are for Z buffer operation."	},
+	{	"B_Z1", 0xF02294, sizeof(uint32_t), "Z1", "These registers are analogous to the intensity registers, and are for Z buffer operation."	},
+	{	"B_Z0", 0xF02298, sizeof(uint32_t), "Z0", "These registers are analogous to the intensity registers, and are for Z buffer operation."	},
+};
 
 
 // 
@@ -78,11 +87,12 @@ model(new QStandardItemModel)
 	fixedFont.setStyleHint(QFont::TypeWriter);
 
 	// Set the new layout with proper identation and readibility
-	model->setColumnCount(4);
-	model->setHeaderData(0, Qt::Horizontal, QObject::tr("Name"));
-	model->setHeaderData(1, Qt::Horizontal, QObject::tr("Address"));
-	model->setHeaderData(2, Qt::Horizontal, QObject::tr("# bits"));
-	model->setHeaderData(3, Qt::Horizontal, QObject::tr("Value"));
+	model->setColumnCount(5);
+	model->setHeaderData(0, Qt::Horizontal, QObject::tr("Register"));
+	model->setHeaderData(1, Qt::Horizontal, QObject::tr("Name"));
+	model->setHeaderData(2, Qt::Horizontal, QObject::tr("Address"));
+	model->setHeaderData(3, Qt::Horizontal, QObject::tr("# bits"));
+	model->setHeaderData(4, Qt::Horizontal, QObject::tr("Value"));
 	//model->setHeaderData(4, Qt::Horizontal, QObject::tr("Reference"));
 	// Information table
 	TableView->setModel(model);
@@ -96,9 +106,10 @@ model(new QStandardItemModel)
 	for (i = 0; i < (sizeof(TabBlitterInfoTable) / sizeof(struct BlitterInfoTable)); i++)
 	{
 		model->insertRow(i);
-		model->setItem(i, 0, new QStandardItem(QString("%1").arg(TabBlitterInfoTable[i].Name)));
-		model->setItem(i, 1, new QStandardItem(QString("0x%1").arg(TabBlitterInfoTable[i].Address, 4, 16, QChar('0'))));
-		model->setItem(i, 2, new QStandardItem(QString("%1").arg(TabBlitterInfoTable[i].NbBits * 8)));
+		model->setItem(i, 0, new QStandardItem(QString("%1").arg(TabBlitterInfoTable[i].RegisterName)));
+		model->setItem(i, 1, new QStandardItem(QString("%1").arg(TabBlitterInfoTable[i].Name)));
+		model->setItem(i, 2, new QStandardItem(QString("0x%1").arg(TabBlitterInfoTable[i].Address, 4, 16, QChar('0'))));
+		model->setItem(i, 3, new QStandardItem(QString("%1").arg(TabBlitterInfoTable[i].NbBytes * 8)));
 		//model->setItem(i, 4, new QStandardItem(QString("%1").arg(TabBlitterInfoTable[i].Type)));
 	}
 
@@ -121,19 +132,22 @@ void HWRegsBlitterBrowserWindow::Reset(void)
 }
 
 
-//
+// Display the value from each Blitter's register
 void HWRegsBlitterBrowserWindow::RefreshContents(void)
 {
 	char string[1024];
 	unsigned int i;
+	ULONGLONG value;
 
 	if (isVisible())
 	{
 		for (i = 0; i < (sizeof(TabBlitterInfoTable) / sizeof(struct BlitterInfoTable)); i++)
 		{
 			// Emulator handles the blitter in a separate array
-			sprintf(string, "0x%08x", BlitterReadLong(TabBlitterInfoTable[i].Address));
-			model->setItem(i, 3, new QStandardItem(QString("%1").arg(string)));
+			//sprintf(string, "0x%08x", BlitterReadLong(TabBlitterInfoTable[i].Address));
+			(TabBlitterInfoTable[i].NbBytes == 4) ? (value = *(uint32_t*)&blitter_ram[TabBlitterInfoTable[i].Address & 0xff]) : (value = *(uint64_t*)&blitter_ram[TabBlitterInfoTable[i].Address & 0xff]);
+			(TabBlitterInfoTable[i].NbBytes == 4) ? sprintf(string, "0x%08x", INV32(value) : sprintf(string, "0x%016x", INV64(value));
+			model->setItem(i, 4, new QStandardItem(QString("%1").arg(string)));
 		}
 	}
 }

--- a/src/gui/mainwin.cpp
+++ b/src/gui/mainwin.cpp
@@ -1972,8 +1972,9 @@ void MainWin::ReadSettings(void)
 	strcpy(vjs.alpineROMPath, settings.value("DefaultROM", "").toString().toUtf8().data());
 	strcpy(vjs.absROMPath, settings.value("DefaultABS", "").toString().toUtf8().data());
 	vjs.refresh = settings.value("refresh", 60).toUInt();
-	vjs.allowWritesToROM = settings.value("writeROM", false).toBool();
+	vjs.allowWritesToROM = settings.value("writeROM", true).toBool();
 	vjs.allowM68KExceptionCatch = settings.value("M68KExceptionCatch", false).toBool();
+	vjs.allowWritesToUnknownLocation = settings.value("WriteUnknownLocation", true).toBool();
 	settings.endGroup();
 
 	// Read settings from the Keybindings
@@ -2282,6 +2283,7 @@ void MainWin::WriteSettings(void)
 	settings.setValue("DefaultABS", vjs.absROMPath);
 	settings.setValue("writeROM", vjs.allowWritesToROM);
 	settings.setValue("M68KExceptionCatch", vjs.allowM68KExceptionCatch);
+	settings.setValue("WriteUnknownLocation", vjs.allowWritesToUnknownLocation);
 	settings.endGroup();
 
 	// Write settings from the Debugger mode

--- a/src/jaguar.cpp
+++ b/src/jaguar.cpp
@@ -19,6 +19,7 @@
 // JPM   Aug./2019  Fix potential emulator freeze after an exception has occured
 // JPM   Feb./2021  Added a specific breakpoint for the M68K bus error exception, and a M68K exception catch detection
 // JPM   Apr./2021  Keep number of M68K cycles used in tracing mode
+// JPM   Jan./2022  Added a writes to unknown memory location catch
 //
 
 
@@ -1952,35 +1953,44 @@ void M68K_show_context(void)
 // $700000 worth of address space! (That is, unless the 68K causes a bus
 // error...)
 
+
+// Catch a byte write to an unknown location
 void jaguar_unknown_writebyte(unsigned address, unsigned data, uint32_t who/*=UNKNOWN*/)
 {
-	m68k_write_unknown_alert(address, "8", data);
+	if (!vjs.allowWritesToUnknownLocation)
+	{
+		m68k_write_unknown_alert(address, "8", data);
 #ifdef LOG_UNMAPPED_MEMORY_ACCESSES
-	WriteLog("Jaguar: Unknown byte %02X written at %08X by %s (M68K PC=%06X)\n", data, address, whoName[who], m68k_get_reg(NULL, M68K_REG_PC));
+		WriteLog("Jaguar: Unknown byte %02X written at %08X by %s (M68K PC=%06X)\n", data, address, whoName[who], m68k_get_reg(NULL, M68K_REG_PC));
 #endif
 #ifdef ABORT_ON_UNMAPPED_MEMORY_ACCESS
-//	extern bool finished;
-	finished = true;
-//	extern bool doDSPDis;
-	if (who == DSP)
-		doDSPDis = true;
+		//	extern bool finished;
+		finished = true;
+		//	extern bool doDSPDis;
+		if (who == DSP)
+			doDSPDis = true;
 #endif
+	}
 }
 
 
+// Catch a word/short write to an unknown location
 void jaguar_unknown_writeword(unsigned address, unsigned data, uint32_t who/*=UNKNOWN*/)
 {
-	m68k_write_unknown_alert(address, "16", data);
+	if (!vjs.allowWritesToUnknownLocation)
+	{
+		m68k_write_unknown_alert(address, "16", data);
 #ifdef LOG_UNMAPPED_MEMORY_ACCESSES
-	WriteLog("Jaguar: Unknown word %04X written at %08X by %s (M68K PC=%06X)\n", data, address, whoName[who], m68k_get_reg(NULL, M68K_REG_PC));
+		WriteLog("Jaguar: Unknown word %04X written at %08X by %s (M68K PC=%06X)\n", data, address, whoName[who], m68k_get_reg(NULL, M68K_REG_PC));
 #endif
 #ifdef ABORT_ON_UNMAPPED_MEMORY_ACCESS
-//	extern bool finished;
-	finished = true;
-//	extern bool doDSPDis;
-	if (who == DSP)
-		doDSPDis = true;
+		//	extern bool finished;
+		finished = true;
+		//	extern bool doDSPDis;
+		if (who == DSP)
+			doDSPDis = true;
 #endif
+	}
 }
 
 

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -13,6 +13,7 @@
 // ---  ----------  -----------------------------------------------------------
 // JLH  01/16/2010  Created this log ;-)
 // JPM  06/06/2016  Visual Studio support
+// JPM  March/2022  Fix the Object list at $0
 //
 
 #include "op.h"
@@ -487,7 +488,8 @@ int bitmapCounter = 0;
 	uint32_t opCyclesToRun = 30000;					// This is a pulled-out-of-the-air value (will need to be fixed, obviously!)
 
 //	if (op_pointer) WriteLog(" new op list at 0x%.8x halfline %i\n",op_pointer,halfline);
-	while (op_pointer)
+	//while (op_pointer)
+	do
 	{
 // *** BEGIN OP PROCESSOR TESTING ONLY ***
 if (interactiveMode && bitmapCounter == objectPtr)
@@ -606,7 +608,7 @@ if (inhibit && op_start_log)
 bitmapCounter++;
 if (!inhibit)	// For OP testing only!
 // *** END OP PROCESSOR TESTING ONLY ***
-			if (halfline >= ypos && height > 0)
+			if ((halfline >= ypos) && (height > 0))
 			{
 				// Believe it or not, this is what the OP actually does...
 				// which is why they're required to be on a dphrase boundary!
@@ -638,8 +640,10 @@ if (!inhibit)	// For OP testing only!
 
 			// KLUDGE: Seems that memory access is mirrored in the first 8MB of
 			// memory...
-			if (op_pointer > 0x1FFFFF && op_pointer < 0x800000)
+			if ((op_pointer > 0x1FFFFF) && (op_pointer < 0x800000))
+			{
 				op_pointer &= 0xFF1FFFFF;	// Knock out bits 21-23
+			}
 
 			break;
 		}
@@ -836,6 +840,7 @@ OP: Scaled bitmap 4x? 4bpp at 34,? hscale=80 fpix=0 data=000756E8 pitch 1 hflipp
 			default:
 				// Basically, if you do this, the OP does nothing. :-)
 				WriteLog("OP: Unimplemented branch condition %i\n", cc);
+				break;
 			}
 			break;
 		}
@@ -854,6 +859,7 @@ OP: Scaled bitmap 4x? 4bpp at 34,? hscale=80 fpix=0 data=000756E8 pitch 1 hflipp
 		}
 		default:
 			WriteLog("OP: Unknown object type %i\n", (uint8_t)p0 & 0x07);
+			break;
 		}
 
 		// Here is a little sanity check to keep the OP from locking up the
@@ -870,6 +876,7 @@ OP: Scaled bitmap 4x? 4bpp at 34,? hscale=80 fpix=0 data=000756E8 pitch 1 hflipp
 		if (!opCyclesToRun)
 			return;
 	}
+	while (op_pointer);
 }
 
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -80,7 +80,8 @@ struct VJSettings
 	uint32_t renderType;
 	uint32_t refresh;
 	bool allowM68KExceptionCatch;								// Allow M68K exception catch
-	bool allowWritesToROM;										// Allow writing to ROM cartdridge
+	bool allowWritesToROM;										// Allow writes to ROM cartdridge
+	bool allowWritesToUnknownLocation;							// Allow writes to unknown memory location
 	uint32_t biosType;											// Bios type used
 	uint32_t jaguarModel;										// Jaguar model
 	size_t nbrdisasmlines;										// Number of lines to show in the M68K tracing window

--- a/src/settings.h
+++ b/src/settings.h
@@ -90,6 +90,7 @@ struct VJSettings
 	bool useFastBlitter;
 	bool displayFullSourceFilename;
 	bool ELFSectionsCheck;
+	bool cygdriveDirRemoval;
 	size_t nbrmemory1browserwindow;								// Number of memory browser windows
 	size_t DRAM_size;											// DRAM size
 


### PR DESCRIPTION
Fixes & improvements, done on the side, during the Blitter's WiP.

* Added a '/cygdrive/' directory detection and removal option.
* Fix #51.
* Add some missing break in switch cases.
* Fixes and improvements for the HW registers Blitter browser.
* Resolve #49.